### PR TITLE
supplement changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@
 - Compatibility with Matomo 5.x
 - Starting using semver for versioning
 
+## v1.1.6
+
+- update: Format time string to real time
+
+## v1.1.5
+
+- update: Remove non-used dependecies
+
 ## v1.1.4
 
 - Fix : stdClass::$avg_time_generation error
@@ -14,10 +22,30 @@
 - Add '-' when no data to display
 - Set min height to widget body
 
+## v1.1.2
+
+- fix: Widget height
+
+## v1.1.1
+
+- update: Add common structure to widget
+
 ## v1.1.0
 
 - Support for Matomo 4.x
 - Fix 1 translation
+
+## v1.0.4
+
+- update plugin.json informations
+
+## v1.0.3
+
+- fix: remove old files
+
+## v1.0.2
+
+- update: CSS class name
 
 ## v1.0.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,24 +1,29 @@
-## Changelog
+# Changelog
 
 ## v5.0.0
+
 - Compatibility with Matomo 5.x
 - Starting using semver for versioning
 
-
 ## v1.1.4
+
 - Fix : stdClass::$avg_time_generation error
 
 ## v1.1.3
+
 - Add '-' when no data to display
 - Set min height to widget body
 
 ## v1.1.0
+
 - Support for Matomo 4.x
 - Fix 1 translation
 
 ## v1.0.1
+
 - Fixing issue from root folder name
 
 ## v1.0.0
+
 - Create many widgets
 - Add translation to french (fr)


### PR DESCRIPTION
The changelog here (https://plugins.matomo.org/KPIWidgets/changelog) was missing some information on some releases. This PR supplements the changelog based on commit messages and tag annotations.